### PR TITLE
Implement skill registry with unit tests

### DIFF
--- a/src/shadowhound_utils/package.xml
+++ b/src/shadowhound_utils/package.xml
@@ -5,9 +5,12 @@
   <description>Utilities for ShadowHound (QoS, image, robot interface shim)</description>
   <maintainer email="you@example.com">You</maintainer>
   <license>MIT</license>
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <test_depend>ament_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
 </package>

--- a/src/shadowhound_utils/setup.cfg
+++ b/src/shadowhound_utils/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = ["test"]

--- a/src/shadowhound_utils/shadowhound_utils/__init__.py
+++ b/src/shadowhound_utils/shadowhound_utils/__init__.py
@@ -1,0 +1,12 @@
+"""ShadowHound utility package exports."""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["RobotIface"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "RobotIface":
+        return import_module(".robot_iface", __name__).RobotIface
+    raise AttributeError(name)

--- a/src/shadowhound_utils/shadowhound_utils/skills.py
+++ b/src/shadowhound_utils/shadowhound_utils/skills.py
@@ -1,0 +1,191 @@
+"""Runtime skill registry and reference skill implementations."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional, Tuple
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
+    from .robot_iface import RobotIface
+
+
+@dataclass(frozen=True)
+class SkillSpec:
+    """Metadata describing a skill implementation."""
+
+    name: str
+    inputs: Mapping[str, type] = field(default_factory=dict)
+    outputs: Optional[Mapping[str, type]] = None
+    timeout_s: float = 10.0
+    safety: Tuple[str, ...] = field(default_factory=tuple)
+    offline_ok: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.name or not isinstance(self.name, str):
+            raise ValueError("SkillSpec.name must be a non-empty string")
+        if self.timeout_s <= 0:
+            raise ValueError("SkillSpec.timeout_s must be > 0")
+        for key in self.inputs:
+            if not isinstance(key, str):
+                raise TypeError("SkillSpec.inputs keys must be strings")
+        if self.outputs is not None:
+            for key in self.outputs:
+                if not isinstance(key, str):
+                    raise TypeError("SkillSpec.outputs keys must be strings")
+
+
+_SKILL_REGISTRY: MutableMapping[str, Tuple[SkillSpec, Callable[..., Any]]] = {}
+
+
+def register_skill(spec: SkillSpec, impl: Callable[..., Any]) -> None:
+    """Register ``impl`` for ``spec`` ensuring name uniqueness."""
+
+    if not callable(impl):
+        raise TypeError("Skill implementation must be callable")
+    if spec.name in _SKILL_REGISTRY:
+        raise ValueError(f"Skill '{spec.name}' already registered")
+    _SKILL_REGISTRY[spec.name] = (spec, impl)
+
+
+def call_skill(name: str, /, **kwargs: Any) -> Any:
+    """Invoke a registered skill validating arguments and honoring timeouts."""
+
+    try:
+        spec, impl = _SKILL_REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown skill '{name}'") from exc
+
+    expected_keys = set(spec.inputs.keys())
+    provided_keys = set(kwargs.keys())
+    missing = expected_keys - provided_keys
+    if missing:
+        missing_args = ", ".join(sorted(missing))
+        raise ValueError(f"Missing arguments for skill '{name}': {missing_args}")
+
+    unexpected = provided_keys - expected_keys
+    if unexpected:
+        unexpected_args = ", ".join(sorted(unexpected))
+        raise ValueError(
+            f"Unexpected arguments for skill '{name}': {unexpected_args}"
+        )
+
+    for key, expected_type in spec.inputs.items():
+        value = kwargs[key]
+        if expected_type is not None and not isinstance(value, expected_type):
+            raise TypeError(
+                f"Argument '{key}' for skill '{name}' must be of type {expected_type}, "
+                f"got {type(value)}"
+            )
+
+    result: Dict[str, Any] = {}
+    error: Dict[str, BaseException] = {}
+
+    def _invoke() -> None:
+        try:
+            result["value"] = impl(**kwargs)
+        except BaseException as exc:  # pragma: no cover - propagate user errors
+            error["exc"] = exc
+
+    thread = threading.Thread(target=_invoke, daemon=True)
+    thread.start()
+    thread.join(timeout=spec.timeout_s)
+    if thread.is_alive():
+        raise TimeoutError(f"Skill '{name}' timed out after {spec.timeout_s} seconds")
+    if error:
+        raise error["exc"]
+    return result.get("value")
+
+
+_ROBOT_IFACE: Optional["RobotIface"] = None
+
+
+def _get_robot_iface() -> "RobotIface":
+    global _ROBOT_IFACE
+    if _ROBOT_IFACE is not None:
+        return _ROBOT_IFACE
+
+    # Lazily import rclpy to avoid mandatory dependency during unit tests.
+    import rclpy
+    from .robot_iface import RobotIface
+
+    if not rclpy.ok():
+        rclpy.init(args=None)
+    _ROBOT_IFACE = RobotIface()
+    return _ROBOT_IFACE
+
+
+def _navigation_rotate(*, yaw: float) -> Dict[str, Any]:
+    robot = _get_robot_iface()
+    angular_speed = 0.6 * (1 if yaw >= 0 else -1)
+    remaining = abs(float(yaw))
+    step = 0.05
+    import rclpy
+
+    while remaining > 0:
+        robot.cmd_vel(0.0, 0.0, angular_speed)
+        rclpy.spin_once(robot, timeout_sec=step)
+        remaining -= abs(angular_speed) * step
+    robot.cmd_vel(0.0, 0.0, 0.0)
+    return {"status": "completed", "yaw": yaw}
+
+
+def _report_say(*, text: str) -> Dict[str, Any]:
+    import rclpy
+    from std_msgs.msg import String
+
+    node = _get_robot_iface()
+    publisher = node.create_publisher(String, "/shadowhound/say", 10)
+    publisher.publish(String(data=text))
+    rclpy.spin_once(node, timeout_sec=0.1)
+    return {"status": "spoken", "text": text}
+
+
+def _perception_snapshot() -> Dict[str, Any]:
+    # Placeholder implementation returning a logical URI reference.
+    timestamp = int(time.time() * 1000)
+    return {"uri": f"package://shadowhound/snapshots/{timestamp}.jpg"}
+
+
+def _register_builtin_skills() -> None:
+    register_skill(
+        SkillSpec(
+            name="navigation.rotate",
+            inputs={"yaw": float},
+            outputs={"status": str, "yaw": float},
+            timeout_s=10.0,
+            safety=("slow_speed",),
+            offline_ok=False,
+        ),
+        _navigation_rotate,
+    )
+    register_skill(
+        SkillSpec(
+            name="report.say",
+            inputs={"text": str},
+            outputs={"status": str, "text": str},
+            timeout_s=5.0,
+            safety=(),
+            offline_ok=True,
+        ),
+        _report_say,
+    )
+    register_skill(
+        SkillSpec(
+            name="perception.snapshot",
+            inputs={},
+            outputs={"uri": str},
+            timeout_s=2.0,
+            safety=("no_motion",),
+            offline_ok=True,
+        ),
+        _perception_snapshot,
+    )
+
+
+_register_builtin_skills()
+
+
+__all__ = ["SkillSpec", "register_skill", "call_skill"]

--- a/src/shadowhound_utils/shadowhound_utils/skills.py
+++ b/src/shadowhound_utils/shadowhound_utils/skills.py
@@ -118,11 +118,11 @@ def _get_robot_iface() -> "RobotIface":
 
 
 def _navigation_rotate(*, yaw: float) -> Dict[str, Any]:
+    import rclpy
     robot = _get_robot_iface()
     angular_speed = 0.6 * (1 if yaw >= 0 else -1)
     remaining = abs(float(yaw))
     step = 0.05
-    import rclpy
 
     while remaining > 0:
         robot.cmd_vel(0.0, 0.0, angular_speed)

--- a/src/shadowhound_utils/test/test_skills.py
+++ b/src/shadowhound_utils/test/test_skills.py
@@ -1,0 +1,63 @@
+import time
+from typing import Dict
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[3] / "src"))
+
+import shadowhound_utils.shadowhound_utils.skills as skills
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry():
+    snapshot = dict(skills._SKILL_REGISTRY)
+    try:
+        yield
+    finally:
+        skills._SKILL_REGISTRY.clear()
+        skills._SKILL_REGISTRY.update(snapshot)
+
+
+def test_register_duplicate_skill_raises():
+    spec = skills.SkillSpec(name="demo.skill", inputs={}, timeout_s=0.1)
+    skills.register_skill(spec, lambda: None)
+    with pytest.raises(ValueError):
+        skills.register_skill(spec, lambda: None)
+
+
+def test_missing_argument_detection():
+    spec = skills.SkillSpec(name="demo.required", inputs={"value": int}, timeout_s=0.1)
+    skills.register_skill(spec, lambda value: value)
+    with pytest.raises(ValueError):
+        skills.call_skill("demo.required")
+
+
+def test_type_validation():
+    spec = skills.SkillSpec(name="demo.types", inputs={"value": int}, timeout_s=0.1)
+    skills.register_skill(spec, lambda value: value)
+    with pytest.raises(TypeError):
+        skills.call_skill("demo.types", value="nope")
+
+
+def test_timeout_behavior():
+    spec = skills.SkillSpec(name="demo.timeout", inputs={}, timeout_s=0.05)
+
+    def slow_skill():
+        time.sleep(0.2)
+
+    skills.register_skill(spec, slow_skill)
+    with pytest.raises(TimeoutError):
+        skills.call_skill("demo.timeout")
+
+
+def test_successful_call_returns_value():
+    spec = skills.SkillSpec(name="demo.success", inputs={"value": int}, timeout_s=0.5)
+
+    def impl(value: int) -> Dict[str, int]:
+        return {"value": value}
+
+    skills.register_skill(spec, impl)
+    assert skills.call_skill("demo.success", value=7) == {"value": 7}


### PR DESCRIPTION
## Summary
- add a reusable SkillSpec dataclass and registry helpers with timeout enforcement and builtin skills
- lazily expose RobotIface from shadowhound_utils and wire pytest configuration
- cover the registry with targeted unit tests and declare ROS/pytest dependencies

## Testing
- python -m pytest src/shadowhound_utils/test

------
https://chatgpt.com/codex/tasks/task_b_68d6d47a7a188333a7a1760c71e4e9f3