### PR TITLE
Add ament CMake configuration for shadowhound_utils

### DIFF
--- a/src/shadowhound_utils/CMakeLists.txt
+++ b/src/shadowhound_utils/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.8)
+project(shadowhound_utils)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_skills test/test_skills.py)
+endif()
+
+ament_package()


### PR DESCRIPTION
## Summary
- add ament-based CMake configuration so the shadowhound_utils package builds correctly
- register the package for installation and wire pytest-based unit tests into colcon

## Testing
- Not run (colcon is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d6dfba81cc8333b00276f98d259401