### PR TITLE
Switch mission agent package to ament_python

### DIFF
--- a/src/shadowhound_mission_agent/package.xml
+++ b/src/shadowhound_mission_agent/package.xml
@@ -5,7 +5,7 @@
   <description>Mission/Conversation agent that calls skills and uses RobotIface.</description>
   <maintainer email="you@example.com">You</maintainer>
   <license>MIT</license>
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
## Summary
- update the mission agent package manifest to declare ament_python as its build tool
- ensure no lingering references to ament_cmake remain in the package metadata

## Testing
- colcon build --packages-select shadowhound_mission_agent *(fails: colcon not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6e53f32608333ba6d54913e7a6927