### PR TITLE
Declare mission agent as ament_python package

### DIFF
--- a/src/shadowhound_mission_agent/package.xml
+++ b/src/shadowhound_mission_agent/package.xml
@@ -10,4 +10,7 @@
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>shadowhound_utils</depend>
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## Summary
- add the ament_python build type export to the mission agent package manifest

## Testing
- `colcon build --packages-select shadowhound_mission_agent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d6e8c47aec83339b2d51bb52882ccd